### PR TITLE
 Support a custom delimiter

### DIFF
--- a/app/src/main/java/com/mube/stringcalculator/domain/usecase/CalculatorUseCaseImp.kt
+++ b/app/src/main/java/com/mube/stringcalculator/domain/usecase/CalculatorUseCaseImp.kt
@@ -1,9 +1,11 @@
 package com.mube.stringcalculator.domain.usecase
 
 import com.mube.stringcalculator.utils.extensions.clearNewLines
+import com.mube.stringcalculator.utils.extensions.getDelimiter
 import com.mube.stringcalculator.utils.extensions.toIntOrZero
 
-private const val DELIMITER = ","
+private const val DEFAULT_DELIMITER = ","
+private const val DELIMITER_CONTROL_SYMBOL = "//"
 
 class CalculatorUseCaseImp : CalculatorUseCase {
 
@@ -11,9 +13,12 @@ class CalculatorUseCaseImp : CalculatorUseCase {
         var sum = 0
 
         if (inputValue.isNotBlank()) {
+            val delimiter = inputValue
+                .getDelimiter(DELIMITER_CONTROL_SYMBOL, DEFAULT_DELIMITER)
+
             val numbers = inputValue
                 .clearNewLines()
-                .split(DELIMITER)
+                .split(delimiter)
 
             numbers.forEach { number ->
                 sum += number.trim().toIntOrZero()

--- a/app/src/main/java/com/mube/stringcalculator/utils/extensions/StringExtensions.kt
+++ b/app/src/main/java/com/mube/stringcalculator/utils/extensions/StringExtensions.kt
@@ -5,3 +5,21 @@ fun String.toIntOrZero(): Int = this.toIntOrNull()?.run {
 }.orZero()
 
 fun String.clearNewLines(): String = replace("\n", "")
+
+fun String.removeText(text: String): String = replace(text, "")
+
+fun String.getDelimiter(delimiterSymbol: String, default: String): String {
+    var delimiter = default
+
+    if (startsWith(delimiterSymbol)) {
+        val newDelimiter = this.firstLine().removeText(delimiterSymbol).trim()
+
+        if (newDelimiter.isNotBlank() && newDelimiter.isChar()) delimiter = newDelimiter
+    }
+
+    return delimiter
+}
+
+fun String.firstLine(): String = split("\n").first()
+
+fun String.isChar(): Boolean = (this.toIntOrZero() == 0)

--- a/app/src/test/java/com/mube/stringcalculator/utils/extensions/ExtensionTest.kt
+++ b/app/src/test/java/com/mube/stringcalculator/utils/extensions/ExtensionTest.kt
@@ -29,4 +29,60 @@ class ExtensionTest {
         assertThat(result).isEqualTo(expected)
     }
 
+    @Test
+    fun delimiterSuccess() {
+        val result = "//$$\n1\n23\n45".getDelimiter("//", ",")
+        val expected = "$$"
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun delimiterNoSymbolError() {
+        val result = "\n1\n23\n45".getDelimiter("//", ",")
+        val expected = ","
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun delimiterNoValueError() {
+        val result = "//\n1\n23\n45".getDelimiter("//", ",")
+        val expected = ","
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun delimiterNumberError() {
+        val result = "//1\n23\n45".getDelimiter("//", ",")
+        val expected = ","
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun firsLineOnly() {
+        val result = "1\n23\n45".firstLine()
+        val expected = "1"
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun valueIsCharSuccess() {
+        val result = "@@".isChar()
+        val expected = true
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun valueIsCharError() {
+        val result = "11".isChar()
+        val expected = false
+
+        assertThat(result).isEqualTo(expected)
+    }
+
 }


### PR DESCRIPTION
. The beginning of your string will now contain a small control code that lets you
set a custom delimiter.
b. Format: “//[delimiter]\n[delimiter separated numbers]”
c. Example: “//;\n1;3;4” - Result: 8
d. In the above you can see that following the double forward slash we set a
semicolon, followed by a new line. We then use that delimiter to split our
numbers.
e. e. Other examples
i. “//$\n1$2$3” - Result: 6
ii. “//@\n2@3@8” - Result: 13