### PR TITLE
Bonus

### DIFF
--- a/app/src/main/java/com/mube/stringcalculator/domain/usecase/CalculatorUseCaseImp.kt
+++ b/app/src/main/java/com/mube/stringcalculator/domain/usecase/CalculatorUseCaseImp.kt
@@ -18,17 +18,17 @@ class CalculatorUseCaseImp(private val resources: Resources) : CalculatorUseCase
         val negatives: MutableList<String> = mutableListOf()
 
         if (inputValue.isNotBlank()) {
-            val delimiter = inputValue
+            val delimiters: List<String> = inputValue
                 .getDelimiter(DELIMITER_CONTROL_SYMBOL, DEFAULT_DELIMITER)
 
-            if (delimiter.isForbiddenDelimiter()) {
+            if (delimiters.isForbiddenDelimiter()) {
                 return Error(resources.getString(R.string.error_delimiter))
             }
 
             val numbers = inputValue
-                .clearDelimiter(DELIMITER_CONTROL_SYMBOL + delimiter)
+                .clearDelimiter(DELIMITER_CONTROL_SYMBOL + delimiters.toSingleString())
                 .clearNewLines()
-                .split(delimiter)
+                .split(*delimiters.toTypedArray())
 
             numbers.forEach { number ->
                 if (number.isNegativeNumber()) {
@@ -42,9 +42,9 @@ class CalculatorUseCaseImp(private val resources: Resources) : CalculatorUseCase
         return if (negatives.isEmpty()) {
             Success(sum)
         } else {
-            Error(resources.getString(R.string.error_negative, negatives.toSingleString()))
+            Error(resources.getString(R.string.error_negative, negatives.toList().toSingleString()))
         }
     }
 }
 
-private fun String.isForbiddenDelimiter(): Boolean = (this == FORBIDDEN_DELIMITER)
+private fun List<String>.isForbiddenDelimiter(): Boolean = (this.any { it == FORBIDDEN_DELIMITER })

--- a/app/src/main/java/com/mube/stringcalculator/presentation/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/mube/stringcalculator/presentation/ui/viewmodel/MainViewModel.kt
@@ -28,7 +28,10 @@ class MainViewModel(private val useCase: CalculatorUseCase) : ViewModel() {
 
     private fun handleResult(result: InputResult) {
         when (result) {
-            is Success -> _result.value = result.value.toString()
+            is Success -> {
+                _result.value = result.value.toString()
+                _errorMsg.value = ""
+            }
             is Error -> {
                 _errorMsg.value = result.message
                 _result.value = ""

--- a/app/src/main/java/com/mube/stringcalculator/utils/extensions/StringExtensions.kt
+++ b/app/src/main/java/com/mube/stringcalculator/utils/extensions/StringExtensions.kt
@@ -1,33 +1,40 @@
 package com.mube.stringcalculator.utils.extensions
 
 fun String.toIntOrZero(): Int = this.toIntOrNull()?.run {
-    toInt()
+    val number = toInt()
+
+    if (number > 1000) 0 else number
 }.orZero()
 
 fun String.clearNewLines(): String = replace("\n", "")
 
 fun String.removeText(text: String): String = replace(text, "")
 
-fun String.getDelimiter(delimiterSymbol: String, default: String): String {
-    var delimiter = default
+fun String.getDelimiter(delimiterSymbol: String, default: String): List<String> {
+    val listDelimiter = mutableListOf(default)
 
     if (startsWith(delimiterSymbol)) {
-        val newDelimiter = this.firstLine().removeText(delimiterSymbol).trim()
+        val delimiterLine = this.firstLine().removeText(delimiterSymbol).trim()
+        val newDelimiterList = delimiterLine.split(",")
 
-        if (newDelimiter.isNotBlank() && newDelimiter.isChar()) delimiter = newDelimiter
+        if (newDelimiterList.isNotEmpty()) {
+            listDelimiter.clear()
+            listDelimiter.addAll(newDelimiterList)
+        }
+
     }
 
-    return delimiter
+    return listDelimiter.toList()
 }
 
 fun String.firstLine(): String = split("\n").first()
 
 fun String.isChar(): Boolean = (this.toIntOrZero() == 0)
 
-fun String.clearWhiteSpaces() : String = replace("\\s".toRegex(), "")
+fun String.clearWhiteSpaces(): String = replace("\\s".toRegex(), "")
 
-fun String.clearDelimiter(delimiter: String) : String = replace(delimiter, "")
+fun String.clearDelimiter(delimiter: String): String = replace(delimiter, "")
 
 fun String.isNegativeNumber(): Boolean = this.startsWith("-")
 
-fun MutableList<String>.toSingleString() = if (this.size == 1) this.first() else joinToString(", ")
+fun List<String>.toSingleString() = if (this.size == 1) this.first() else joinToString(", ")

--- a/app/src/test/java/com/mube/stringcalculator/utils/extensions/ExtensionTest.kt
+++ b/app/src/test/java/com/mube/stringcalculator/utils/extensions/ExtensionTest.kt
@@ -22,6 +22,22 @@ class ExtensionTest {
     }
 
     @Test
+    fun stringToLargeIntSuccess() {
+        val result = "1001".toIntOrZero()
+        val expected = 0
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun stringToLargeIntError() {
+        val result = "1000".toIntOrZero()
+        val expected = 1000
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
     fun clearNewLinesExtension() {
         val result = "1\n23\n45".clearNewLines()
         val expected = "12345"
@@ -103,7 +119,7 @@ class ExtensionTest {
 
     @Test
     fun listToSingleString() {
-        val result = mutableListOf("1", "2", "3", "4", "5").toSingleString()
+        val result = listOf("1", "2", "3", "4", "5").toSingleString()
         val expected = "1, 2, 3, 4, 5"
 
         assertThat(result).isEqualTo(expected)
@@ -111,7 +127,7 @@ class ExtensionTest {
 
     @Test
     fun listToSingleStringWithOneValue() {
-        val result = mutableListOf("1").toSingleString()
+        val result = listOf("1").toSingleString()
         val expected = "1"
 
         assertThat(result).isEqualTo(expected)


### PR DESCRIPTION
1. Numbers larger than 1000 should be ignored.
a. Example “2,1001” - Result: 2
2. Delimiters can be arbitrary length
a. “//***\n1***2***3” - Result 6
3. Allow for multiple delimiters
a. “//$,@\n1$2@3” - Result 6
4. Combine 2 and 3 bonus questions. Allow multiple delimiters of arbitrary length